### PR TITLE
Fixed an error that the API returns response code 415.

### DIFF
--- a/cognitive-services/cognitive-services/textToSpeech.js
+++ b/cognitive-services/cognitive-services/textToSpeech.js
@@ -60,7 +60,8 @@ module.exports = function(RED) {
 						'X-Search-AppId' : config.appId,
 						'X-Search-ClientID' : node.Id,
 						'X-Microsoft-OutputFormat' : config.outputFormat,
-						'User-Agent' : config.userAgent
+						'User-Agent' : config.userAgent,
+						'Content-Type': 'application/ssml+xml'
 					},
 					body : xmlContent.replace(/\{(.+?)\}/g, function(match, index) {
 						if( index == "payload" )


### PR DESCRIPTION
When executed Text-to-Speech node, the API that is called inside the node returns error status code `415` like below.

So I appended `Content-Type: application/ssml+xml` based on [this document](https://docs.microsoft.com/en-us/azure/cognitive-services/speech/api-reference-rest/bingvoiceoutput) and confirmed that it works. Please review and approved it. 

```json
{
    "statusCode": 415,
    "body": "",
    "headers": {
        "x-msedge-ref": "Ref A: <string> Ref B: <string> Ref C: 2018-10-19T10:30:46Z",
        "date": "Fri, 19 Oct 2018 10:30:46 GMT",
        "connection": "close",
        "content-length": "0"
    },
    "request": {
        "uri": {
            "protocol": "https:",
            "slashes": true,
            "auth": null,
            "host": "speech.platform.bing.com",
            "port": 443,
            "hostname": "speech.platform.bing.com",
            "hash": null,
            "search": null,
            "query": null,
            "pathname": "/synthesize",
            "path": "/synthesize",
            "href": "https://speech.platform.bing.com/synthesize"
        },
        "method": "POST",
        "headers": {
            "Authorization": "Bearer <bearer string>",
            "X-Search-AppId": "",
            "X-Microsoft-OutputFormat": "audio-16khz-32kbitrate-mono-mp3",
            "User-Agent": "Linux",
            "content-length": 179
        }
    }
}
```